### PR TITLE
Refactor/#69 infer csv header type 2

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -161,27 +161,7 @@ export type CSVRecord<Header extends ReadonlyArray<string>> = Record<
   string
 >;
 
-type Concat<T extends any[]> = T extends [infer F, ...infer R]
-  ? R extends any[]
-    ? F & Concat<R>
-    : F
-  : // biome-ignore lint/complexity/noBannedTypes: <explanation>
-    {};
-
-type Replace<
-  Target extends string,
-  From extends string,
-  To extends string,
-> = Target extends `${infer A}${From}${infer B}`
-  ? Replace<`${A}${To}${B}`, From, To>
-  : Target;
-
-type Split<
-  Char extends string,
-  Delimiter extends string = typeof COMMA,
-> = Char extends `${infer F}${Delimiter}${infer R}`
-  ? [F, ...Split<R, Delimiter>]
-  : [Char];
+type Newline = typeof CR | typeof CRLF | typeof LF;
 
 type Join<
   Chars extends ReadonlyArray<string | number | boolean | bigint>,
@@ -190,145 +170,49 @@ type Join<
 > = Chars extends readonly [infer F, ...infer R]
   ? F extends string
     ? R extends string[]
-      ? `${F extends `${string}${Newline}${string}`
+      ? `${F extends `${string}${Newline | Delimiter}${string}`
           ? `${Quotation}${F}${Quotation}`
           : F}${R extends [] ? "" : Delimiter}${Join<R, Delimiter, Quotation>}`
       : string
     : string
   : "";
 
-type Newline = typeof CR | typeof CRLF | typeof LF;
-type DummyNewline<NL extends Newline> =
-  `web-csv-toolbox.DummyNewline-${NL extends typeof CRLF
-    ? "crlf"
-    : NL extends typeof CR
-      ? "cr"
-      : "lf"}`;
-type DummyDelimiter = "web-csv-toolbox.DummyDelimiter";
-
-type SplitNewline<T extends string> =
-  T extends `${infer A}${typeof CRLF}${infer B}`
-    ? [...Split<A, typeof CRLF>, ...SplitNewline<B>]
-    : T extends `${infer A}${typeof CR}${infer B}`
-      ? [...Split<A, typeof CR>, ...SplitNewline<B>]
-      : T extends `${infer A}${typeof LF}${infer B}`
-        ? [...Split<A, typeof LF>, ...SplitNewline<B>]
-        : [T];
-
-type Newline2DummyNewline<T extends string> =
-  T extends `${infer A}${typeof CRLF}${infer B}`
-    ? Newline2DummyNewline<`${A}${DummyNewline<typeof CRLF>}${B}`>
-    : T extends `${infer A}${typeof CR}${infer B}`
-      ? Newline2DummyNewline<`${A}${DummyNewline<typeof CR>}${B}`>
-      : T extends `${infer A}${typeof LF}${infer B}`
-        ? Newline2DummyNewline<`${A}${DummyNewline<typeof LF>}${B}`>
-        : T;
-
-type DummyNewline2Newline<T extends string> =
-  T extends `${infer A}${DummyNewline<typeof CRLF>}${infer B}`
-    ? DummyNewline2Newline<`${A}${typeof CRLF}${B}`>
-    : T extends `${infer A}${DummyNewline<typeof CR>}${infer B}`
-      ? DummyNewline2Newline<`${A}${typeof CR}${B}`>
-      : T extends `${infer A}${DummyNewline<typeof LF>}${infer B}`
-        ? DummyNewline2Newline<`${A}${typeof LF}${B}`>
-        : T;
-
-type Escape<
+type Split<
   CSVSource extends string,
   Delimiter extends string = typeof COMMA,
   Quotation extends string = typeof DOUBLE_QUOTE,
-> = CSVSource extends `${infer A}${Quotation}${infer B}${Quotation}${infer C}`
-  ? `${A}${Newline2DummyNewline<Replace<B, Delimiter, DummyDelimiter>>}${Escape<
-      C,
-      Delimiter,
-      Quotation
-    >}`
-  : CSVSource;
+  Escaping extends boolean = false,
+  Current extends string = "",
+  Result extends string[] = [],
+> = CSVSource extends `${infer F}${infer R}`
+  ? F extends Quotation
+    ? Escaping extends true
+      ? Split<R, Delimiter, Quotation, false, Current, Result>
+      : Split<R, Delimiter, Quotation, true, Current, Result>
+    : F extends Delimiter
+      ? Escaping extends true
+        ? Split<R, Delimiter, Quotation, true, `${Current}${F}`, Result>
+        : Split<R, Delimiter, Quotation, false, "", [...Result, Current]>
+      : Split<R, Delimiter, Quotation, Escaping, `${Current}${F}`, Result>
+  : [...Result, Current] extends [""]
+    ? readonly string[]
+    : readonly [...Result, Current];
 
-type Row2Record<H extends PropertyKey[], V extends any[][]> = {
-  [K in keyof V]: Concat<{
-    [P in keyof H]: { [Key in H[P]]: V[K][Extract<keyof V[K], P>] };
-  }>;
-};
-
-type ToCSVRows<
-  T extends string,
-  Delimiter extends string = typeof COMMA,
+type CSVBody<
+  CSVSource extends string,
   Quotation extends string = typeof DOUBLE_QUOTE,
-> = SplitNewline<Escape<T, Delimiter, Quotation>> extends infer R
-  ? {
-      [K in keyof R]: R[K] extends string ? DummyNewline2Newline<R[K]> : never;
-    }
-  : ReadonlyArray<string>;
-
-/**
- * Generate a CSV header tuple from a CSVString.
- *
- * @category Types
- *
- * @example Default
- *
- * ```ts
- * const csv = `name,age
- * Alice,42
- * Bob,69`;
- *
- * type _ = ToParsedCSVRecords<typeof csv>
- * // [
- * //   { name: "Alice"; age: "42"; },
- * //   { name: "Bob"; age: "69" }
- * // ]
- *```
- *
- * @example With different delimiter and quotation
- *
- * ```ts
- * const csv = `name@$a
- * ge$
- * $Ali
- * ce$@42
- * Bob@69`;
- *
- * type _ = ToParsedCSVRecords<typeof csv, "@", "$">
- * // [
- * //   { name: "Ali\nce"; "a\nge": "42"; },
- * //   { name: "Bob"; "a\nge": "69" }
- * // ]
- * ```
- */
-export type ToParsedCSVRecords<
-  T extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
-> = ToCSVRows<T, Delimiter, Quotation> extends [
-  infer H extends string,
-  ...infer R,
-]
-  ? R extends [string, ...string[]]
-    ? Row2Record<
-        Split<H, Delimiter> extends infer H2 extends PropertyKey[]
-          ? {
-              [K in keyof H2]: Replace<
-                H2[K] extends string ? H2[K] : string,
-                DummyDelimiter,
-                Delimiter
-              >;
-            }
-          : PropertyKey[],
-        {
-          [K in keyof R]: Split<R[K], Delimiter> extends infer R2
-            ? {
-                [K in keyof R2]: Replace<
-                  R2[K] extends string ? R2[K] : string,
-                  DummyDelimiter,
-                  Delimiter
-                >;
-              }
-            : ReadonlyArray<string>;
-        }
-      >
-    : CSVRecord<Split<H, Delimiter>>
-  : CSVRecord<readonly string[]>;
+  Escaping extends boolean = false,
+> = CSVSource extends `${infer F}${infer R}`
+  ? F extends Quotation
+    ? Escaping extends true
+      ? CSVBody<R, Quotation, false>
+      : CSVBody<R, Quotation, true>
+    : F extends Newline
+      ? Escaping extends true
+        ? CSVBody<R, Quotation, true>
+        : R
+      : CSVBody<R, Quotation, Escaping>
+  : "";
 
 /**
  * Generate a CSV header tuple from a CSVString.
@@ -367,20 +251,9 @@ export type PickCSVHeader<
   | `${infer Source}`
   // biome-ignore lint/suspicious/noRedeclare: <explanation>
   | ReadableStream<infer Source>
-  ? ToCSVRows<Source, Delimiter, Quotation> extends [
-      infer Header extends string,
-      ...string[],
-    ]
-    ? Split<Header, Delimiter> extends infer R
-      ? {
-          [K in keyof R]: Replace<
-            R[K] extends string ? R[K] : never,
-            DummyDelimiter,
-            Delimiter
-          >;
-        }
-      : ReadonlyArray<string>
-    : ReadonlyArray<string>
+  ? Source extends `${infer H}${Newline}${CSVBody<Source, Quotation>}`
+    ? Split<H, Delimiter, Quotation>
+    : Split<Source, Delimiter, Quotation>
   : ReadonlyArray<string>;
 
 /**
@@ -394,12 +267,8 @@ export type CSVString<
   Quotation extends string = typeof DOUBLE_QUOTE,
 > = Header extends readonly [string, ...string[]]
   ?
-      | `${Join<Header, Delimiter, Quotation>}${typeof LF}${string}`
-      | ReadableStream<`${Join<
-          Header,
-          Delimiter,
-          Quotation
-        >}${typeof LF}${string}`>
+      | `${Join<Header, Delimiter, Quotation>}`
+      | ReadableStream<`${Join<Header, Delimiter, Quotation>}`>
   : string | ReadableStream<string>;
 
 /**

--- a/src/parseStringToArraySync.test-d.ts
+++ b/src/parseStringToArraySync.test-d.ts
@@ -30,20 +30,7 @@ Bob,36,Los Angeles,90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          age: "24";
-          city: "New York";
-          zip: "10001";
-        },
-        {
-          name: "Bob";
-          age: "36";
-          city: "Los Angeles";
-          zip: "90001";
-        },
-      ]
+      CSVRecord<["name", "age", "city", "zip"]>[]
     >();
 
     expectTypeOf(parseStringToArraySync(csv2)).toMatchTypeOf<
@@ -104,59 +91,16 @@ les'@'@9
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
+      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
     >();
 
     expectTypeOf(
       parseStringToArraySync(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n\n": "24";
-          "c\nity": "Ne\nw York";
-          "\nzi\np": "10\n001";
-        },
-        {
-          name: "Bob";
-          "age\n\n": "36";
-          "c\nity": "Los Ange\n\nles";
-          "\nzi\np": "9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv4, { delimiter: "@", quotation: "'" }),
@@ -164,41 +108,11 @@ les'@'@9
 
     expectTypeOf(
       parseStringToArraySync(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "na\rme": "Alice";
-          age: "24";
-          "ci\r\r\nty": "New\r\n York";
-          "z\nip": "10001";
-        },
-        {
-          "na\rme": "Bob";
-          age: "3\r\n6";
-          "ci\r\r\nty": "Los Angeles";
-          "z\nip": "90\r\n001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "@name": "Alice@";
-          "age\n\n": "24";
-          "c\n@ity@": "@Ne\nw York";
-          "\nzi\np": "10\n00@1";
-        },
-        {
-          "@name": "Bob";
-          "age\n\n": "36";
-          "c\n@ity@": "Lo@s Ange\n\nles";
-          "\nzi\np": "@9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
   });
 });
 

--- a/src/parseStringToArraySync.ts
+++ b/src/parseStringToArraySync.ts
@@ -1,11 +1,6 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import type {
-  CSVRecord,
-  ParseOptions,
-  PickCSVHeader,
-  ToParsedCSVRecords,
-} from "./common/types.ts";
+import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 
 export function parseStringToArraySync<
@@ -23,21 +18,11 @@ export function parseStringToArraySync<
     delimiter?: Delimiter;
     quotation?: Quotation;
   },
-): ToParsedCSVRecords<CSVSource, Delimiter, Quotation> extends infer R extends
-  CSVRecord<readonly string[]>[]
-  ? R
-  : CSVRecord<Header>[];
+): CSVRecord<Header>[];
 export function parseStringToArraySync<
   CSVSource extends string,
   Header extends ReadonlyArray<string> = PickCSVHeader<CSVSource>,
->(
-  csv: CSVSource,
-  options?: ParseOptions<Header>,
-): ToParsedCSVRecords<CSVSource> extends infer R extends CSVRecord<
-  readonly string[]
->[]
-  ? R
-  : CSVRecord<Header>[];
+>(csv: CSVSource, options?: ParseOptions<Header>): CSVRecord<Header>[];
 export function parseStringToArraySync<Header extends ReadonlyArray<string>>(
   csv: string,
   options?: ParseOptions<Header>,

--- a/src/parseStringToArraySyncWASM.test-d.ts
+++ b/src/parseStringToArraySyncWASM.test-d.ts
@@ -32,20 +32,7 @@ Bob,36,Los Angeles,90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          age: "24";
-          city: "New York";
-          zip: "10001";
-        },
-        {
-          name: "Bob";
-          age: "36";
-          city: "Los Angeles";
-          zip: "90001";
-        },
-      ]
+      CSVRecord<["name", "age", "city", "zip"]>[]
     >();
 
     expectTypeOf(parseStringToArraySyncWASM(csv2)).toMatchTypeOf<
@@ -106,59 +93,16 @@ les'@'@9
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
+      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
     >();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n\n": "24";
-          "c\nity": "Ne\nw York";
-          "\nzi\np": "10\n001";
-        },
-        {
-          name: "Bob";
-          "age\n\n": "36";
-          "c\nity": "Los Ange\n\nles";
-          "\nzi\np": "9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv4, { delimiter: "@", quotation: "'" }),
@@ -166,41 +110,11 @@ les'@'@9
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "na\rme": "Alice";
-          age: "24";
-          "ci\r\r\nty": "New\r\n York";
-          "z\nip": "10001";
-        },
-        {
-          "na\rme": "Bob";
-          age: "3\r\n6";
-          "ci\r\r\nty": "Los Angeles";
-          "z\nip": "90\r\n001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "@name": "Alice@";
-          "age\n\n": "24";
-          "c\n@ity@": "@Ne\nw York";
-          "\nzi\np": "10\n00@1";
-        },
-        {
-          "@name": "Bob";
-          "age\n\n": "36";
-          "c\n@ity@": "Lo@s Ange\n\nles";
-          "\nzi\np": "@9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
   });
 });
 

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -3,7 +3,6 @@ import type {
   CSVRecord,
   CommonOptions,
   PickCSVHeader,
-  ToParsedCSVRecords,
 } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import type { loadWASM } from "./loadWASM.ts";
@@ -58,21 +57,11 @@ export function parseStringToArraySyncWASM<
     delimiter?: Delimiter;
     quotation?: Quotation;
   },
-): ToParsedCSVRecords<CSVSource, Delimiter, Quotation> extends infer R extends
-  CSVRecord<readonly string[]>[]
-  ? R
-  : CSVRecord<Header>[];
+): CSVRecord<Header>[];
 export function parseStringToArraySyncWASM<
   CSVSource extends string,
   Header extends ReadonlyArray<string> = PickCSVHeader<CSVSource>,
->(
-  csv: CSVSource,
-  options?: CommonOptions,
-): ToParsedCSVRecords<CSVSource> extends infer R extends CSVRecord<
-  readonly string[]
->[]
-  ? R
-  : CSVRecord<Header>[];
+>(csv: CSVSource, options?: CommonOptions): CSVRecord<Header>[];
 export function parseStringToArraySyncWASM<
   Header extends ReadonlyArray<string>,
 >(csv: string, options?: CommonOptions): CSVRecord<Header>[];


### PR DESCRIPTION
The main changes are as follows.

### Type `Split`
This type is designed to split a string based on a specified delimiter. It incorporates complex logic to handle delimiters that appear within quoted segments (i.e., escaped segments).

Specifically, it has the following functionalities:

- CSVSource: The string to be processed.
- Delimiter: The delimiter character (default is a comma).
- Quotation: The quotation character (default is a double quote).
- Escaping: A boolean indicating whether the current context is within quotes. Delimiters within quotes are ignored.
- Current: The character currently being processed.
- Result: An array of fields that have been processed so far.

This type sequentially scans the input CSV string and adds fields to an array each time a delimiter appears. If a delimiter appears inside a quoted segment, it is treated as part of the field, and if a delimiter appears outside of quotes, it is added to the array as a new field.

### Type `CSVBody`
This type recursively parses CSV format text while processing quotes and newlines, with the goal of extracting the body of the CSV.

Specifically, it has the following functionalities:

- CSVSource: The string to be processed.
- Quotation: The quotation character (default is a double quote).
- Escaping: A boolean indicating whether the current context is within quotes.

This type scans the string one character at a time, switching the escape state upon encountering a quotation mark. While in the escaped state, it ignores newline characters (which signify a new line) and treats characters as part of the normal string until the quote is closed. When encountering the first newline outside of quotes, it returns the following string as the body of the CSV.