### PR TITLE
fix: simplify the type

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,7 +1,7 @@
 import { assertCommonOptions } from "./assertCommonOptions.ts";
 import { Field, FieldDelimiter, RecordDelimiter } from "./common/constants.ts";
 import type { CommonOptions, Token } from "./common/types.ts";
-import { COMMA, CRLF, DOUBLE_QUOTE, LF } from "./constants.ts";
+import { CRLF, DEFAULT_DELIMITER, DEFAULT_QUOTATION, LF } from "./constants.ts";
 import { escapeRegExp } from "./utils/escapeRegExp.ts";
 
 export class Lexer {
@@ -14,8 +14,8 @@ export class Lexer {
   #flush = false;
 
   constructor({
-    delimiter = COMMA,
-    quotation = DOUBLE_QUOTE,
+    delimiter = DEFAULT_DELIMITER,
+    quotation = DEFAULT_QUOTATION,
   }: CommonOptions = {}) {
     assertCommonOptions({ delimiter, quotation });
     this.#delimiter = delimiter;

--- a/src/common/types.test-d.ts
+++ b/src/common/types.test-d.ts
@@ -1,0 +1,362 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { CR, CRLF, LF } from "../constants";
+import type {
+  ExtractCSVHeader,
+  Join,
+  PickCSVHeader,
+  Split,
+} from "../utils/types";
+
+const case1csv1 = '"na\nme,",age,city,zip';
+
+const case1csv2 = `"name","age
+","city","zi
+p"
+Alice,24,New York,10001
+Bob,36,Los Angeles,90001`;
+
+const case1csv3 = `"na"me","ag\ne
+",city,"zi
+p""
+Alice,24,New York,10001
+Bob,36,Los Angeles,90001`;
+
+const case2csv1 = "'na\nme@'@age@city@zip";
+
+const case2csv2 = `'name'@'age
+'@'city'@'zi
+p'
+Alice@24@New York@10001
+Bob@36@Los Angeles@90001`;
+
+const case2csv3 = `'name'@'age
+
+'@'c
+ity'@'
+zi
+p'
+Alice@'24'@'Ne
+w York'@'10
+001'
+Bob@36@'Los Ange
+
+les'@'9
+0001'`;
+
+const case2csv4 = `'name'@'age
+
+'@'c
+ity'@'
+zi
+p'`;
+
+const case2csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
+
+const case2csv6 = `'@name'@'age
+
+'@'c
+@ity@'@'
+zi
+p'
+'Alice@'@'24'@'@Ne
+w York'@'10
+00@1'
+Bob@36@'Lo@s Ange
+
+les'@'@9
+0001'`;
+
+const case2csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
+const case2csv8 =
+  "'namdelimitere'delimiteragedelimitercitydelimiterzip\naadelimiterbbdelimiterccdelimiterdd\needelimiterffdelimiterggdelimiterhh";
+
+const case2csv9 =
+  "name@quotationa\ngequotation@city@zip\naa@quotationbb\nquotation@cc@dd\nee@quotationffquotation@gg@hh";
+
+describe("Join", () => {
+  describe("Generate new string by concatenating all of the elements in array", () => {
+    it("Default", () => {
+      expectTypeOf<Join<[]>>().toEqualTypeOf<"">();
+      expectTypeOf<
+        Join<["name", "age", "city", "zip"]>
+      >().toEqualTypeOf<"name,age,city,zip">();
+    });
+
+    it("With different delimiter and quotation", () => {
+      expectTypeOf<Join<[], "@", "$">>().toEqualTypeOf<"">();
+      expectTypeOf<
+        Join<["name", "age", "city", "zip"], "@", "$">
+      >().toEqualTypeOf<"name@age@city@zip">();
+    });
+
+    it("Escape newlines and delimiters", () => {
+      expectTypeOf<Join<[], "@", "$">>().toEqualTypeOf<"">();
+      expectTypeOf<
+        Join<["name", "a\nge", "city", "zip"]>
+      >().toEqualTypeOf<'name,"a\nge",city,zip'>();
+    });
+  });
+});
+
+describe("Split", () => {
+  describe("Generate a delimiter-separated tuple from a string", () => {
+    it("Default", () => {
+      expectTypeOf<Split<"">>().toEqualTypeOf<readonly string[]>();
+      expectTypeOf<Split<"name,age,city,zip">>().toEqualTypeOf<
+        readonly ["name", "age", "city", "zip"]
+      >();
+      expectTypeOf<Split<'"na"me","ag\ne",city,"zip""'>>().toEqualTypeOf<
+        readonly ['na"me', "ag\ne", "city", 'zip"']
+      >();
+    });
+
+    it("With different delimiter and quotation", () => {
+      expectTypeOf<Split<"", "@", "$">>().toEqualTypeOf<readonly string[]>();
+      expectTypeOf<
+        Split<"$na$me$@$ag\ne$@city@$zip$$", "@", "$">
+      >().toEqualTypeOf<readonly ["na$me", "ag\ne", "city", "zip$"]>();
+      expectTypeOf<
+        Split<'"name\r\n"\r\nage\r\ncity\r\nzip', "\r\n">
+      >().toEqualTypeOf<readonly ["name\r\n", "age", "city", "zip"]>();
+      expectTypeOf<
+        Split<"namedelimiteragedelimitercitydelimiterzip", "delimiter">
+      >().toEqualTypeOf<readonly ["name", "age", "city", "zip"]>();
+      expectTypeOf<
+        Split<"name,quotationa\ngequotation,city,zip", ",", "quotation">
+      >().toEqualTypeOf<readonly ["name", "a\nge", "city", "zip"]>();
+    });
+  });
+});
+
+describe("ExtractCSVHeader", () => {
+  describe("Extract a CSV header string from a CSVString", () => {
+    it("Default", () => {
+      expectTypeOf<ExtractCSVHeader<"">>().toEqualTypeOf<"">();
+      expectTypeOf<ExtractCSVHeader<ReadableStream<"">>>().toEqualTypeOf<"">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case1csv1>
+      >().toEqualTypeOf<'"na\nme,",age,city,zip'>();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case1csv1>>
+      >().toEqualTypeOf<'"na\nme,",age,city,zip'>();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case1csv2>
+      >().toEqualTypeOf<'"name","age\n","city","zi\np"'>();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case1csv2>>
+      >().toEqualTypeOf<'"name","age\n","city","zi\np"'>();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case1csv2>
+      >().toEqualTypeOf<'"name","age\n","city","zi\np"'>();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case1csv2>>
+      >().toEqualTypeOf<'"name","age\n","city","zi\np"'>();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case1csv3>
+      >().toEqualTypeOf<'"na"me","ag\ne\n",city,"zi\np""'>();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case1csv3>>
+      >().toEqualTypeOf<'"na"me","ag\ne\n",city,"zi\np""'>();
+    });
+
+    it("With different delimiter and quotation", () => {
+      expectTypeOf<ExtractCSVHeader<"", "@", "$">>().toEqualTypeOf<"">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<"">, "@", "$">
+      >().toEqualTypeOf<"">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv1, "@", "'">
+      >().toEqualTypeOf<"'na\nme@'@age@city@zip">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv1>, "@", "'">
+      >().toEqualTypeOf<"'na\nme@'@age@city@zip">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv2, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n'@'city'@'zi\np'">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv2>, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n'@'city'@'zi\np'">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv3, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n\n'@'c\nity'@'\nzi\np'">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv3>, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n\n'@'c\nity'@'\nzi\np'">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv4, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n\n'@'c\nity'@'\nzi\np'">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv4>, "@", "'">
+      >().toEqualTypeOf<"'name'@'age\n\n'@'c\nity'@'\nzi\np'">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv5, "@", "'">
+      >().toEqualTypeOf<"'na\rme'@'age'@'ci\r\r\nty'@'z\nip'">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv5>, "@", "'">
+      >().toEqualTypeOf<"'na\rme'@'age'@'ci\r\r\nty'@'z\nip'">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv6, "@", "'">
+      >().toEqualTypeOf<"'@name'@'age\n\n'@'c\n@ity@'@'\nzi\np'">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv6>, "@", "'">
+      >().toEqualTypeOf<"'@name'@'age\n\n'@'c\n@ity@'@'\nzi\np'">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv7, "@", "'">
+      >().toEqualTypeOf<"'@name'@'a'g'e\n\n'@'c\n@i''ty@'@'\n'zi\np''">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv7>, "@", "'">
+      >().toEqualTypeOf<"'@name'@'a'g'e\n\n'@'c\n@i''ty@'@'\n'zi\np''">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv8, "delimiter", "'">
+      >().toEqualTypeOf<"'namdelimitere'delimiteragedelimitercitydelimiterzip">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv8>, "delimiter", "'">
+      >().toEqualTypeOf<"'namdelimitere'delimiteragedelimitercitydelimiterzip">();
+
+      expectTypeOf<
+        ExtractCSVHeader<typeof case2csv9, "@", "quotation">
+      >().toEqualTypeOf<"name@quotationa\ngequotation@city@zip">();
+      expectTypeOf<
+        ExtractCSVHeader<ReadableStream<typeof case2csv9>, "@", "quotation">
+      >().toEqualTypeOf<"name@quotationa\ngequotation@city@zip">();
+    });
+  });
+});
+
+describe("PickCSVHeader", () => {
+  describe("Generates a delimiter-separated tuple of CSV headers from a CSVString", () => {
+    it("Default", () => {
+      expectTypeOf<PickCSVHeader<"">>().toEqualTypeOf<readonly string[]>();
+      expectTypeOf<PickCSVHeader<ReadableStream<"">>>().toEqualTypeOf<
+        readonly string[]
+      >();
+
+      expectTypeOf<PickCSVHeader<typeof case1csv1>>().toEqualTypeOf<
+        readonly ["na\nme,", "age", "city", "zip"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case1csv1>>
+      >().toEqualTypeOf<readonly ["na\nme,", "age", "city", "zip"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case1csv2>>().toEqualTypeOf<
+        readonly ["name", "age\n", "city", "zi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case1csv2>>
+      >().toEqualTypeOf<readonly ["name", "age\n", "city", "zi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case1csv2>>().toEqualTypeOf<
+        readonly ["name", "age\n", "city", "zi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case1csv2>>
+      >().toEqualTypeOf<readonly ["name", "age\n", "city", "zi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case1csv3>>().toEqualTypeOf<
+        readonly ['na"me', "ag\ne\n", "city", 'zi\np"']
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case1csv3>>
+      >().toEqualTypeOf<readonly ['na"me', "ag\ne\n", "city", 'zi\np"']>();
+    });
+
+    it("With different delimiter and quotation", () => {
+      expectTypeOf<PickCSVHeader<"", "@", "$">>().toEqualTypeOf<
+        readonly string[]
+      >();
+      expectTypeOf<PickCSVHeader<ReadableStream<"">, "@", "$">>().toEqualTypeOf<
+        readonly string[]
+      >();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv1, "@", "'">>().toEqualTypeOf<
+        readonly ["na\nme@", "age", "city", "zip"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv1>, "@", "'">
+      >().toEqualTypeOf<readonly ["na\nme@", "age", "city", "zip"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv2, "@", "'">>().toEqualTypeOf<
+        readonly ["name", "age\n", "city", "zi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv2>, "@", "'">
+      >().toEqualTypeOf<readonly ["name", "age\n", "city", "zi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv3, "@", "'">>().toEqualTypeOf<
+        readonly ["name", "age\n\n", "c\nity", "\nzi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv3>, "@", "'">
+      >().toEqualTypeOf<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv4, "@", "'">>().toEqualTypeOf<
+        readonly ["name", "age\n\n", "c\nity", "\nzi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv4>, "@", "'">
+      >().toEqualTypeOf<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv5, "@", "'">>().toEqualTypeOf<
+        readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv5>, "@", "'">
+      >().toEqualTypeOf<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv6, "@", "'">>().toEqualTypeOf<
+        readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv6>, "@", "'">
+      >().toEqualTypeOf<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>();
+
+      expectTypeOf<PickCSVHeader<typeof case2csv7, "@", "'">>().toEqualTypeOf<
+        readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]
+      >();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv7>, "@", "'">
+      >().toEqualTypeOf<
+        readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]
+      >();
+
+      expectTypeOf<
+        PickCSVHeader<typeof case2csv8, "delimiter", "'">
+      >().toEqualTypeOf<readonly ["namdelimitere", "age", "city", "zip"]>();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv8>, "delimiter", "'">
+      >().toEqualTypeOf<readonly ["namdelimitere", "age", "city", "zip"]>();
+
+      expectTypeOf<
+        PickCSVHeader<typeof case2csv9, "@", "quotation">
+      >().toEqualTypeOf<readonly ["name", "a\nge", "city", "zip"]>();
+      expectTypeOf<
+        PickCSVHeader<ReadableStream<typeof case2csv9>, "@", "quotation">
+      >().toEqualTypeOf<readonly ["name", "a\nge", "city", "zip"]>();
+    });
+  });
+});

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,4 +1,4 @@
-import type { COMMA, DOUBLE_QUOTE } from "../constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "../constants.ts";
 import type { Join } from "../utils/types.ts";
 import type { Field, FieldDelimiter, RecordDelimiter } from "./constants.ts";
 
@@ -169,8 +169,8 @@ export type CSVRecord<Header extends ReadonlyArray<string>> = Record<
  */
 export type CSVString<
   Header extends ReadonlyArray<string> = [],
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
 > = Header extends readonly [string, ...string[]]
   ?
       | Join<Header, Delimiter, Quotation>
@@ -195,8 +195,8 @@ export type CSVBinary =
  */
 export type CSV<
   Header extends ReadonlyArray<string> = [],
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
 > = Header extends []
   ? CSVString | CSVBinary
   : CSVString<Header, Delimiter, Quotation>;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -218,7 +218,7 @@ type ExtractHeader<
         ? ExtractHeader<R, Delimiter, Quotation, true, `${Result}${F}`>
         : Result
       : ExtractHeader<R, Delimiter, Quotation, Escaping, `${Result}${F}`>
-  : "";
+  : Result;
 
 /**
  * Generate a CSV header tuple from a CSVString.
@@ -257,13 +257,7 @@ export type PickCSVHeader<
   | `${infer Source}`
   // biome-ignore lint/suspicious/noRedeclare: <explanation>
   | ReadableStream<infer Source>
-  ? Source extends `${ExtractHeader<
-      Source,
-      Delimiter,
-      Quotation
-    >}${Newline}${string}`
-    ? Split<ExtractHeader<Source, Delimiter, Quotation>, Delimiter, Quotation>
-    : Split<Source, Delimiter, Quotation>
+  ? Split<ExtractHeader<Source, Delimiter, Quotation>, Delimiter, Quotation>
   : ReadonlyArray<string>;
 
 /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -161,27 +161,7 @@ export type CSVRecord<Header extends ReadonlyArray<string>> = Record<
   string
 >;
 
-type Concat<T extends any[]> = T extends [infer F, ...infer R]
-  ? R extends any[]
-    ? F & Concat<R>
-    : F
-  : // biome-ignore lint/complexity/noBannedTypes: <explanation>
-    {};
-
-type Replace<
-  Target extends string,
-  From extends string,
-  To extends string,
-> = Target extends `${infer A}${From}${infer B}`
-  ? Replace<`${A}${To}${B}`, From, To>
-  : Target;
-
-type Split<
-  Char extends string,
-  Delimiter extends string = typeof COMMA,
-> = Char extends `${infer F}${Delimiter}${infer R}`
-  ? [F, ...Split<R, Delimiter>]
-  : [Char];
+type Newline = typeof CR | typeof CRLF | typeof LF;
 
 type Join<
   Chars extends ReadonlyArray<string | number | boolean | bigint>,
@@ -197,138 +177,42 @@ type Join<
     : string
   : "";
 
-type Newline = typeof CR | typeof CRLF | typeof LF;
-type DummyNewline<NL extends Newline> =
-  `web-csv-toolbox.DummyNewline-${NL extends typeof CRLF
-    ? "crlf"
-    : NL extends typeof CR
-      ? "cr"
-      : "lf"}`;
-type DummyDelimiter = "web-csv-toolbox.DummyDelimiter";
-
-type SplitNewline<T extends string> =
-  T extends `${infer A}${typeof CRLF}${infer B}`
-    ? [...Split<A, typeof CRLF>, ...SplitNewline<B>]
-    : T extends `${infer A}${typeof CR}${infer B}`
-      ? [...Split<A, typeof CR>, ...SplitNewline<B>]
-      : T extends `${infer A}${typeof LF}${infer B}`
-        ? [...Split<A, typeof LF>, ...SplitNewline<B>]
-        : [T];
-
-type Newline2DummyNewline<T extends string> =
-  T extends `${infer A}${typeof CRLF}${infer B}`
-    ? Newline2DummyNewline<`${A}${DummyNewline<typeof CRLF>}${B}`>
-    : T extends `${infer A}${typeof CR}${infer B}`
-      ? Newline2DummyNewline<`${A}${DummyNewline<typeof CR>}${B}`>
-      : T extends `${infer A}${typeof LF}${infer B}`
-        ? Newline2DummyNewline<`${A}${DummyNewline<typeof LF>}${B}`>
-        : T;
-
-type DummyNewline2Newline<T extends string> =
-  T extends `${infer A}${DummyNewline<typeof CRLF>}${infer B}`
-    ? DummyNewline2Newline<`${A}${typeof CRLF}${B}`>
-    : T extends `${infer A}${DummyNewline<typeof CR>}${infer B}`
-      ? DummyNewline2Newline<`${A}${typeof CR}${B}`>
-      : T extends `${infer A}${DummyNewline<typeof LF>}${infer B}`
-        ? DummyNewline2Newline<`${A}${typeof LF}${B}`>
-        : T;
-
-type Escape<
+type Split<
   CSVSource extends string,
   Delimiter extends string = typeof COMMA,
   Quotation extends string = typeof DOUBLE_QUOTE,
-> = CSVSource extends `${infer A}${Quotation}${infer B}${Quotation}${infer C}`
-  ? `${A}${Newline2DummyNewline<Replace<B, Delimiter, DummyDelimiter>>}${Escape<
-      C,
-      Delimiter,
-      Quotation
-    >}`
-  : CSVSource;
+  Escaping extends boolean = false,
+  Current extends string = "",
+  Result extends string[] = [],
+> = CSVSource extends `${infer F}${infer R}`
+  ? F extends Quotation
+    ? Escaping extends true
+      ? Split<R, Delimiter, Quotation, false, Current, Result>
+      : Split<R, Delimiter, Quotation, true, Current, Result>
+    : F extends Delimiter
+      ? Escaping extends true
+        ? Split<R, Delimiter, Quotation, true, `${Current}${F}`, Result>
+        : Split<R, Delimiter, Quotation, false, "", [...Result, Current]>
+      : Split<R, Delimiter, Quotation, Escaping, `${Current}${F}`, Result>
+  : [...Result, Current] extends [""]
+    ? readonly string[]
+    : readonly [...Result, Current];
 
-type Row2Record<H extends PropertyKey[], V extends any[][]> = {
-  [K in keyof V]: Concat<{
-    [P in keyof H]: { [Key in H[P]]: V[K][Extract<keyof V[K], P>] };
-  }>;
-};
-
-type ToCSVRows<
-  T extends string,
-  Delimiter extends string = typeof COMMA,
+type CSVBody<
+  CSVSource extends string,
   Quotation extends string = typeof DOUBLE_QUOTE,
-> = SplitNewline<Escape<T, Delimiter, Quotation>> extends infer R
-  ? {
-      [K in keyof R]: R[K] extends string ? DummyNewline2Newline<R[K]> : never;
-    }
-  : ReadonlyArray<string>;
-
-/**
- * Generate a CSV header tuple from a CSVString.
- *
- * @category Types
- *
- * @example Default
- *
- * ```ts
- * const csv = `name,age
- * Alice,42
- * Bob,69`;
- *
- * type _ = ToParsedCSVRecords<typeof csv>
- * // [
- * //   { name: "Alice"; age: "42"; },
- * //   { name: "Bob"; age: "69" }
- * // ]
- *```
- *
- * @example With different delimiter and quotation
- *
- * ```ts
- * const csv = `name@$a
- * ge$
- * $Ali
- * ce$@42
- * Bob@69`;
- *
- * type _ = ToParsedCSVRecords<typeof csv, "@", "$">
- * // [
- * //   { name: "Ali\nce"; "a\nge": "42"; },
- * //   { name: "Bob"; "a\nge": "69" }
- * // ]
- * ```
- */
-export type ToParsedCSVRecords<
-  T extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
-> = ToCSVRows<T, Delimiter, Quotation> extends [
-  infer H extends string,
-  ...infer R,
-]
-  ? R extends [string, ...string[]]
-    ? Row2Record<
-        Split<H, Delimiter> extends infer H2 extends PropertyKey[]
-          ? {
-              [K in keyof H2]: Replace<
-                H2[K] extends string ? H2[K] : string,
-                DummyDelimiter,
-                Delimiter
-              >;
-            }
-          : PropertyKey[],
-        {
-          [K in keyof R]: Split<R[K], Delimiter> extends infer R2
-            ? {
-                [K in keyof R2]: Replace<
-                  R2[K] extends string ? R2[K] : string,
-                  DummyDelimiter,
-                  Delimiter
-                >;
-              }
-            : ReadonlyArray<string>;
-        }
-      >
-    : CSVRecord<Split<H, Delimiter>>
-  : CSVRecord<readonly string[]>;
+  Escaping extends boolean = false,
+> = CSVSource extends `${infer F}${infer R}`
+  ? F extends Quotation
+    ? Escaping extends true
+      ? CSVBody<R, Quotation, false>
+      : CSVBody<R, Quotation, true>
+    : F extends Newline
+      ? Escaping extends true
+        ? CSVBody<R, Quotation, true>
+        : R
+      : CSVBody<R, Quotation, Escaping>
+  : "";
 
 /**
  * Generate a CSV header tuple from a CSVString.
@@ -367,20 +251,9 @@ export type PickCSVHeader<
   | `${infer Source}`
   // biome-ignore lint/suspicious/noRedeclare: <explanation>
   | ReadableStream<infer Source>
-  ? ToCSVRows<Source, Delimiter, Quotation> extends [
-      infer Header extends string,
-      ...string[],
-    ]
-    ? Split<Header, Delimiter> extends infer R
-      ? {
-          [K in keyof R]: Replace<
-            R[K] extends string ? R[K] : never,
-            DummyDelimiter,
-            Delimiter
-          >;
-        }
-      : ReadonlyArray<string>
-    : ReadonlyArray<string>
+  ? Source extends `${infer H}${Newline}${CSVBody<Source, Quotation>}`
+    ? Split<H, Delimiter, Quotation>
+    : Split<Source, Delimiter, Quotation>
   : ReadonlyArray<string>;
 
 /**
@@ -394,12 +267,8 @@ export type CSVString<
   Quotation extends string = typeof DOUBLE_QUOTE,
 > = Header extends readonly [string, ...string[]]
   ?
-      | `${Join<Header, Delimiter, Quotation>}${typeof LF}${string}`
-      | ReadableStream<`${Join<
-          Header,
-          Delimiter,
-          Quotation
-        >}${typeof LF}${string}`>
+      | `${Join<Header, Delimiter, Quotation>}`
+      | ReadableStream<`${Join<Header, Delimiter, Quotation>}`>
   : string | ReadableStream<string>;
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,9 @@ export const COMMA = ",";
  * DOUBLE_QUOTE is a symbol for double quote(").
  */
 export const DOUBLE_QUOTE = '"';
+
+export const DEFAULT_DELIMITER = COMMA;
+export type DEFAULT_DELIMITER = typeof DEFAULT_DELIMITER;
+
+export const DEFAULT_QUOTATION = DOUBLE_QUOTE;
+export type DEFAULT_QUOTATION = typeof DEFAULT_QUOTATION;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,9 @@ export const COMMA = ",";
  * DOUBLE_QUOTE is a symbol for double quote(").
  */
 export const DOUBLE_QUOTE = '"';
+
+export const DEFAULT_DELIMITER = COMMA;
+export type DEFAULT_DELIMITER = typeof DEFAULT_DELIMITER;
+
+export const DEFAULT_QUOTATION = DOUBLE_QUOTE;
+export type DEFAULT_QUOTATION = typeof DEFAULT_DELIMITER;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,13 @@
 export const CR = "\r";
+export type CR = typeof CR;
+
 export const CRLF = "\r\n";
+export type CRLF = typeof CRLF;
+
 export const LF = "\n";
+export type LF = typeof LF;
+
+export type Newline = CRLF | CR | LF;
 
 /**
  * COMMA is a symbol for comma(,).

--- a/src/escapeField.ts
+++ b/src/escapeField.ts
@@ -1,6 +1,6 @@
 import type { assertCommonOptions } from "./assertCommonOptions.ts";
 import type { CommonOptions } from "./common/types.ts";
-import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import { occurrences } from "./utils/occurrences.ts";
 
 export interface EscapeFieldOptions extends CommonOptions {
@@ -34,8 +34,8 @@ function specialCheckFordelimiterIsRepetitionOfOneTypeOfCharacter(
 export function escapeField(
   value: string,
   {
-    quotation = DOUBLE_QUOTE,
-    delimiter = COMMA,
+    delimiter = DEFAULT_DELIMITER,
+    quotation = DEFAULT_QUOTATION,
     quote,
   }: EscapeFieldOptions = {},
 ): string {

--- a/src/parse.test-d.ts
+++ b/src/parse.test-d.ts
@@ -131,6 +131,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parse(csv1)).toEqualTypeOf<
       AsyncIterableIterator<
@@ -165,6 +179,12 @@ les'@'@9
     expectTypeOf(parse(csv6, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
       AsyncIterableIterator<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(parse(csv7, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
+      AsyncIterableIterator<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
 

--- a/src/parse.test-d.ts
+++ b/src/parse.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parse } from "./parse.ts";
 import type {
   CSV,
@@ -52,14 +51,8 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parse(csv1)).toEqualTypeOf<
-      AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(parse(csv2)).toEqualTypeOf<
       AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
 
@@ -82,109 +75,19 @@ Bob,36,Los Angeles,90001`;
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parse(csv1)).toEqualTypeOf<
+    expectTypeOf(parse(csv1, { delimiter: "*", quotation: "$" })).toEqualTypeOf<
       AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv2, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv3, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv4, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv5, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv6, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(parse(csv7, { delimiter: "@", quotation: "'" })).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
 
@@ -204,64 +107,14 @@ les'@'@9
       >
     >();
 
-    expectTypeOf(parse(new ReadableStream<typeof csv1>())).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
     expectTypeOf(
-      parse(new ReadableStream<typeof csv2>(), {
-        delimiter: "@",
-        quotation: "'",
+      parse(new ReadableStream<typeof csv1>(), {
+        delimiter: "*",
+        quotation: "$",
       }),
     ).toEqualTypeOf<
       AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parse(new ReadableStream<typeof csv3>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parse(new ReadableStream<typeof csv4>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parse(new ReadableStream<typeof csv5>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parse(new ReadableStream<typeof csv6>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,7 @@ import type {
   ParseBinaryOptions,
   ParseOptions,
 } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import { parseBinary } from "./parseBinary.ts";
 import { parseResponse } from "./parseResponse.ts";
 import { parseString } from "./parseString.ts";
@@ -122,8 +122,8 @@ import type { PickCSVHeader } from "./utils/types.ts";
  */
 export function parse<
   CSVSource extends CSVString,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,7 +5,6 @@ import type {
   CSVString,
   ParseBinaryOptions,
   ParseOptions,
-  PickCSVHeader,
 } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import { parseBinary } from "./parseBinary.ts";
@@ -14,6 +13,7 @@ import { parseString } from "./parseString.ts";
 import { parseStringStream } from "./parseStringStream.ts";
 import { parseUint8ArrayStream } from "./parseUint8ArrayStream.ts";
 import * as internal from "./utils/convertThisAsyncIterableIteratorToArray.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 /**
  * Parse CSV to records.

--- a/src/parseString.test-d.ts
+++ b/src/parseString.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import {
   type CSVRecord,
   type ParseOptions,
@@ -29,135 +28,29 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseString(csv1)).toEqualTypeOf<
-      AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(parseString(csv2)).toEqualTypeOf<
       AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
   });
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parseString(csv1)).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
     expectTypeOf(
-      parseString(csv2, { delimiter: "@", quotation: "'" }),
+      parseString(csv1, { delimiter: "*", quotation: "$" }),
     ).toEqualTypeOf<
       AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseString(csv3, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseString(csv4, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseString(csv5, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseString(csv6, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseString(csv7, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parseString.test-d.ts
+++ b/src/parseString.test-d.ts
@@ -92,6 +92,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseString(csv1)).toEqualTypeOf<
       AsyncIterableIterator<
@@ -136,6 +150,14 @@ les'@'@9
     ).toEqualTypeOf<
       AsyncIterableIterator<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(
+      parseString(csv7, { delimiter: "@", quotation: "'" }),
+    ).toEqualTypeOf<
+      AsyncIterableIterator<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
   });

--- a/src/parseString.ts
+++ b/src/parseString.ts
@@ -1,5 +1,5 @@
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import { parseStringToArraySync } from "./parseStringToArraySync.ts";
 import { parseStringToIterableIterator } from "./parseStringToIterableIterator.ts";
 import { parseStringToStream } from "./parseStringToStream.ts";
@@ -34,8 +34,8 @@ import type { PickCSVHeader } from "./utils/types.ts";
  */
 export function parseString<
   CSVSource extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseString.ts
+++ b/src/parseString.ts
@@ -1,9 +1,10 @@
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import { parseStringToArraySync } from "./parseStringToArraySync.ts";
 import { parseStringToIterableIterator } from "./parseStringToIterableIterator.ts";
 import { parseStringToStream } from "./parseStringToStream.ts";
 import * as internal from "./utils/convertThisAsyncIterableIteratorToArray.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 /**
  * Parse CSV string to records.

--- a/src/parseStringStream.test-d.ts
+++ b/src/parseStringStream.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import {
   type CSVRecord,
   type ParseOptions,
@@ -35,17 +34,9 @@ describe("csv literal ReadableStream parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
       parseStringStream(new ReadableStream<typeof csv1>()),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv2>()),
     ).toEqualTypeOf<
       AsyncIterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
@@ -53,141 +44,24 @@ Bob,36,Los Angeles,90001`;
 });
 
 describe("csv literal ReadableStream parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv1>()),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv2>(), {
-        delimiter: "@",
-        quotation: "'",
+      parseStringStream(new ReadableStream<typeof csv1>(), {
+        delimiter: "*",
+        quotation: "$",
       }),
     ).toEqualTypeOf<
       AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv3>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv4>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv5>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv6>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStream(new ReadableStream<typeof csv7>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      AsyncIterableIterator<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parseStringStream.test-d.ts
+++ b/src/parseStringStream.test-d.ts
@@ -102,6 +102,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
       parseStringStream(new ReadableStream<typeof csv1>()),
@@ -163,6 +177,17 @@ les'@'@9
     ).toEqualTypeOf<
       AsyncIterableIterator<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(
+      parseStringStream(new ReadableStream<typeof csv7>(), {
+        delimiter: "@",
+        quotation: "'",
+      }),
+    ).toEqualTypeOf<
+      AsyncIterableIterator<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
   });

--- a/src/parseStringStream.ts
+++ b/src/parseStringStream.ts
@@ -1,5 +1,5 @@
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import { parseStringStreamToStream } from "./parseStringStreamToStream.ts";
 import { convertStreamToAsyncIterableIterator } from "./utils/convertStreamToAsyncIterableIterator.ts";
 import * as internal from "./utils/convertThisAsyncIterableIteratorToArray.ts";
@@ -41,8 +41,8 @@ import type { PickCSVHeader } from "./utils/types.ts";
  */
 export function parseStringStream<
   CSVSource extends ReadableStream<string>,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseStringStream.ts
+++ b/src/parseStringStream.ts
@@ -1,8 +1,9 @@
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import { parseStringStreamToStream } from "./parseStringStreamToStream.ts";
 import { convertStreamToAsyncIterableIterator } from "./utils/convertStreamToAsyncIterableIterator.ts";
 import * as internal from "./utils/convertThisAsyncIterableIteratorToArray.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 /**
  * Parse CSV string stream to records.

--- a/src/parseStringStreamToStream.test-d.ts
+++ b/src/parseStringStreamToStream.test-d.ts
@@ -99,6 +99,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
       parseStringStreamToStream(new ReadableStream<typeof csv1>()),
@@ -156,6 +170,17 @@ les'@'@9
     ).toEqualTypeOf<
       ReadableStream<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(
+      parseStringStreamToStream(new ReadableStream<typeof csv7>(), {
+        delimiter: "@",
+        quotation: "'",
+      }),
+    ).toEqualTypeOf<
+      ReadableStream<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
   });

--- a/src/parseStringStreamToStream.test-d.ts
+++ b/src/parseStringStreamToStream.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parseStringStreamToStream } from "./parseStringStreamToStream.ts";
 import type { CSVRecord, ParseOptions } from "./web-csv-toolbox.ts";
 
@@ -32,17 +31,9 @@ describe("csv literal ReadableStream parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
       parseStringStreamToStream(new ReadableStream<typeof csv1>()),
-    ).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv2>()),
     ).toEqualTypeOf<
       ReadableStream<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
@@ -50,137 +41,24 @@ Bob,36,Los Angeles,90001`;
 });
 
 describe("csv literal ReadableStream parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv1>()),
-    ).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv2>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv3>(), {
-        delimiter: "@",
-        quotation: "'",
+      parseStringStreamToStream(new ReadableStream<typeof csv1>(), {
+        delimiter: "*",
+        quotation: "$",
       }),
     ).toEqualTypeOf<
       ReadableStream<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv4>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv5>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv6>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringStreamToStream(new ReadableStream<typeof csv7>(), {
-        delimiter: "@",
-        quotation: "'",
-      }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parseStringStreamToStream.ts
+++ b/src/parseStringStreamToStream.ts
@@ -1,8 +1,9 @@
 import { LexerTransformer } from "./LexerTransformer.ts";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import { pipeline } from "./utils/pipeline.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringStreamToStream<
   CSVSource extends ReadableStream<string>,

--- a/src/parseStringStreamToStream.ts
+++ b/src/parseStringStreamToStream.ts
@@ -1,14 +1,14 @@
 import { LexerTransformer } from "./LexerTransformer.ts";
 import { RecordAssemblerTransformer } from "./RecordAssemblerTransformer.ts";
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import { pipeline } from "./utils/pipeline.ts";
 import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringStreamToStream<
   CSVSource extends ReadableStream<string>,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseStringToArraySync.test-d.ts
+++ b/src/parseStringToArraySync.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parseStringToArraySync } from "./parseStringToArraySync.ts";
 import type { CSVRecord, ParseOptions } from "./web-csv-toolbox.ts";
 
@@ -26,112 +25,28 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      CSVRecord<["name", "age", "city", "zip"]>[]
-    >();
-
-    expectTypeOf(parseStringToArraySync(csv2)).toMatchTypeOf<
       CSVRecord<["name", "age", "city", "zip"]>[]
     >();
   });
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
-    >();
-
     expectTypeOf(
-      parseStringToArraySync(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySync(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySync(csv4, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySync(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySync(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySync(csv7, { delimiter: "@", quotation: "'" }),
+      parseStringToArraySync(csv1, { delimiter: "*", quotation: "$" }),
     ).toMatchTypeOf<
-      CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>[]
+      CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>[]
     >();
   });
 });

--- a/src/parseStringToArraySync.test-d.ts
+++ b/src/parseStringToArraySync.test-d.ts
@@ -30,20 +30,7 @@ Bob,36,Los Angeles,90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          age: "24";
-          city: "New York";
-          zip: "10001";
-        },
-        {
-          name: "Bob";
-          age: "36";
-          city: "Los Angeles";
-          zip: "90001";
-        },
-      ]
+      CSVRecord<["name", "age", "city", "zip"]>[]
     >();
 
     expectTypeOf(parseStringToArraySync(csv2)).toMatchTypeOf<
@@ -104,59 +91,16 @@ les'@'@9
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
+      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
     >();
 
     expectTypeOf(
       parseStringToArraySync(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n\n": "24";
-          "c\nity": "Ne\nw York";
-          "\nzi\np": "10\n001";
-        },
-        {
-          name: "Bob";
-          "age\n\n": "36";
-          "c\nity": "Los Ange\n\nles";
-          "\nzi\np": "9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv4, { delimiter: "@", quotation: "'" }),
@@ -164,41 +108,11 @@ les'@'@9
 
     expectTypeOf(
       parseStringToArraySync(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "na\rme": "Alice";
-          age: "24";
-          "ci\r\r\nty": "New\r\n York";
-          "z\nip": "10001";
-        },
-        {
-          "na\rme": "Bob";
-          age: "3\r\n6";
-          "ci\r\r\nty": "Los Angeles";
-          "z\nip": "90\r\n001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
 
     expectTypeOf(
       parseStringToArraySync(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "@name": "Alice@";
-          "age\n\n": "24";
-          "c\n@ity@": "@Ne\nw York";
-          "\nzi\np": "10\n00@1";
-        },
-        {
-          "@name": "Bob";
-          "age\n\n": "36";
-          "c\n@ity@": "Lo@s Ange\n\nles";
-          "\nzi\np": "@9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
   });
 });
 

--- a/src/parseStringToArraySync.test-d.ts
+++ b/src/parseStringToArraySync.test-d.ts
@@ -89,6 +89,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySync(csv1)).toMatchTypeOf<
       CSVRecord<["name", "age\n", "city", "zi\np"]>[]
@@ -113,6 +127,12 @@ les'@'@9
     expectTypeOf(
       parseStringToArraySync(csv6, { delimiter: "@", quotation: "'" }),
     ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
+
+    expectTypeOf(
+      parseStringToArraySync(csv7, { delimiter: "@", quotation: "'" }),
+    ).toMatchTypeOf<
+      CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>[]
+    >();
   });
 });
 

--- a/src/parseStringToArraySync.ts
+++ b/src/parseStringToArraySync.ts
@@ -1,7 +1,8 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToArraySync<
   CSVSource extends string,

--- a/src/parseStringToArraySync.ts
+++ b/src/parseStringToArraySync.ts
@@ -1,11 +1,6 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import type {
-  CSVRecord,
-  ParseOptions,
-  PickCSVHeader,
-  ToParsedCSVRecords,
-} from "./common/types.ts";
+import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 
 export function parseStringToArraySync<
@@ -23,21 +18,11 @@ export function parseStringToArraySync<
     delimiter?: Delimiter;
     quotation?: Quotation;
   },
-): ToParsedCSVRecords<CSVSource, Delimiter, Quotation> extends infer R extends
-  CSVRecord<readonly string[]>[]
-  ? R
-  : CSVRecord<Header>[];
+): CSVRecord<Header>[];
 export function parseStringToArraySync<
   CSVSource extends string,
   Header extends ReadonlyArray<string> = PickCSVHeader<CSVSource>,
->(
-  csv: CSVSource,
-  options?: ParseOptions<Header>,
-): ToParsedCSVRecords<CSVSource> extends infer R extends CSVRecord<
-  readonly string[]
->[]
-  ? R
-  : CSVRecord<Header>[];
+>(csv: CSVSource, options?: ParseOptions<Header>): CSVRecord<Header>[];
 export function parseStringToArraySync<Header extends ReadonlyArray<string>>(
   csv: string,
   options?: ParseOptions<Header>,

--- a/src/parseStringToArraySync.ts
+++ b/src/parseStringToArraySync.ts
@@ -1,13 +1,13 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToArraySync<
   CSVSource extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseStringToArraySyncWASM.test-d.ts
+++ b/src/parseStringToArraySyncWASM.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parseStringToArraySyncWASM } from "./parseStringToArraySyncWASM.ts";
 import type { CSVRecord, ParseOptions } from "./web-csv-toolbox.ts";
 
@@ -28,112 +27,28 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      CSVRecord<["name", "age", "city", "zip"]>[]
-    >();
-
-    expectTypeOf(parseStringToArraySyncWASM(csv2)).toMatchTypeOf<
       CSVRecord<["name", "age", "city", "zip"]>[]
     >();
   });
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
-    >();
-
     expectTypeOf(
-      parseStringToArraySyncWASM(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySyncWASM(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySyncWASM(csv4, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySyncWASM(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySyncWASM(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
-
-    expectTypeOf(
-      parseStringToArraySyncWASM(csv7, { delimiter: "@", quotation: "'" }),
+      parseStringToArraySyncWASM(csv1, { delimiter: "*", quotation: "$" }),
     ).toMatchTypeOf<
-      CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>[]
+      CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>[]
     >();
   });
 });

--- a/src/parseStringToArraySyncWASM.test-d.ts
+++ b/src/parseStringToArraySyncWASM.test-d.ts
@@ -32,20 +32,7 @@ Bob,36,Los Angeles,90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          age: "24";
-          city: "New York";
-          zip: "10001";
-        },
-        {
-          name: "Bob";
-          age: "36";
-          city: "Los Angeles";
-          zip: "90001";
-        },
-      ]
+      CSVRecord<["name", "age", "city", "zip"]>[]
     >();
 
     expectTypeOf(parseStringToArraySyncWASM(csv2)).toMatchTypeOf<
@@ -106,59 +93,16 @@ les'@'@9
 
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
+      CSVRecord<["name", "age\n", "city", "zi\np"]>[]
     >();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv2, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n": "24";
-          city: "New York";
-          "zi\np": "10001";
-        },
-        {
-          name: "Bob";
-          "age\n": "36";
-          city: "Los Angeles";
-          "zi\np": "90001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n", "city", "zi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv3, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          name: "Alice";
-          "age\n\n": "24";
-          "c\nity": "Ne\nw York";
-          "\nzi\np": "10\n001";
-        },
-        {
-          name: "Bob";
-          "age\n\n": "36";
-          "c\nity": "Los Ange\n\nles";
-          "\nzi\np": "9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["name", "age\n\n", "c\nity", "\nzi\np"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv4, { delimiter: "@", quotation: "'" }),
@@ -166,41 +110,11 @@ les'@'@9
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv5, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "na\rme": "Alice";
-          age: "24";
-          "ci\r\r\nty": "New\r\n York";
-          "z\nip": "10001";
-        },
-        {
-          "na\rme": "Bob";
-          age: "3\r\n6";
-          "ci\r\r\nty": "Los Angeles";
-          "z\nip": "90\r\n001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["na\rme", "age", "ci\r\r\nty", "z\nip"]>[]>();
 
     expectTypeOf(
       parseStringToArraySyncWASM(csv6, { delimiter: "@", quotation: "'" }),
-    ).toMatchTypeOf<
-      [
-        {
-          "@name": "Alice@";
-          "age\n\n": "24";
-          "c\n@ity@": "@Ne\nw York";
-          "\nzi\np": "10\n00@1";
-        },
-        {
-          "@name": "Bob";
-          "age\n\n": "36";
-          "c\n@ity@": "Lo@s Ange\n\nles";
-          "\nzi\np": "@9\n0001";
-        },
-      ]
-    >();
+    ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
   });
 });
 

--- a/src/parseStringToArraySyncWASM.test-d.ts
+++ b/src/parseStringToArraySyncWASM.test-d.ts
@@ -91,6 +91,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToArraySyncWASM(csv1)).toMatchTypeOf<
       CSVRecord<["name", "age\n", "city", "zi\np"]>[]
@@ -115,6 +129,12 @@ les'@'@9
     expectTypeOf(
       parseStringToArraySyncWASM(csv6, { delimiter: "@", quotation: "'" }),
     ).toMatchTypeOf<CSVRecord<["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>[]>();
+
+    expectTypeOf(
+      parseStringToArraySyncWASM(csv7, { delimiter: "@", quotation: "'" }),
+    ).toMatchTypeOf<
+      CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>[]
+    >();
   });
 });
 

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -3,7 +3,6 @@ import type {
   CSVRecord,
   CommonOptions,
   PickCSVHeader,
-  ToParsedCSVRecords,
 } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import type { loadWASM } from "./loadWASM.ts";
@@ -58,21 +57,11 @@ export function parseStringToArraySyncWASM<
     delimiter?: Delimiter;
     quotation?: Quotation;
   },
-): ToParsedCSVRecords<CSVSource, Delimiter, Quotation> extends infer R extends
-  CSVRecord<readonly string[]>[]
-  ? R
-  : CSVRecord<Header>[];
+): CSVRecord<Header>[];
 export function parseStringToArraySyncWASM<
   CSVSource extends string,
   Header extends ReadonlyArray<string> = PickCSVHeader<CSVSource>,
->(
-  csv: CSVSource,
-  options?: CommonOptions,
-): ToParsedCSVRecords<CSVSource> extends infer R extends CSVRecord<
-  readonly string[]
->[]
-  ? R
-  : CSVRecord<Header>[];
+>(csv: CSVSource, options?: CommonOptions): CSVRecord<Header>[];
 export function parseStringToArraySyncWASM<
   Header extends ReadonlyArray<string>,
 >(csv: string, options?: CommonOptions): CSVRecord<Header>[];

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -1,6 +1,10 @@
 import { parseStringToArraySync } from "web-csv-toolbox-wasm";
 import type { CSVRecord, CommonOptions } from "./common/types.ts";
-import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import {
+  DEFAULT_DELIMITER,
+  DEFAULT_QUOTATION,
+  DOUBLE_QUOTE,
+} from "./constants.ts";
 import type { loadWASM } from "./loadWASM.ts";
 import type { PickCSVHeader } from "./utils/types.ts";
 
@@ -41,8 +45,8 @@ import type { PickCSVHeader } from "./utils/types.ts";
  */
 export function parseStringToArraySyncWASM<
   CSVSource extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,
@@ -66,7 +70,8 @@ export function parseStringToArraySyncWASM<Header extends readonly string[]>(
   csv: string,
   options: CommonOptions = {},
 ): CSVRecord<Header>[] {
-  const { delimiter = COMMA, quotation = DOUBLE_QUOTE } = options;
+  const { delimiter = DEFAULT_DELIMITER, quotation = DEFAULT_QUOTATION } =
+    options;
   if (typeof delimiter !== "string" || delimiter.length !== 1) {
     throw new Error("Invalid delimiter, must be a single character on WASM.");
   }

--- a/src/parseStringToArraySyncWASM.ts
+++ b/src/parseStringToArraySyncWASM.ts
@@ -1,11 +1,8 @@
 import { parseStringToArraySync } from "web-csv-toolbox-wasm";
-import type {
-  CSVRecord,
-  CommonOptions,
-  PickCSVHeader,
-} from "./common/types.ts";
+import type { CSVRecord, CommonOptions } from "./common/types.ts";
 import { COMMA, DOUBLE_QUOTE } from "./constants.ts";
 import type { loadWASM } from "./loadWASM.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 /**
  * Parse CSV string to record of arrays.

--- a/src/parseStringToIterableIterator.test-d.ts
+++ b/src/parseStringToIterableIterator.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parseStringToIterableIterator } from "./parseStringToIterableIterator.ts";
 import type { CSVRecord, ParseOptions } from "./web-csv-toolbox.ts";
 
@@ -28,131 +27,29 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToIterableIterator(csv1)).toEqualTypeOf<
-      IterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(parseStringToIterableIterator(csv2)).toEqualTypeOf<
       IterableIterator<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
   });
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parseStringToIterableIterator(csv1)).toEqualTypeOf<
-      IterableIterator<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
     expectTypeOf(
-      parseStringToIterableIterator(csv2, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      IterableIterator<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
-    expectTypeOf(
-      parseStringToIterableIterator(csv3, { delimiter: "@", quotation: "'" }),
+      parseStringToIterableIterator(csv1, { delimiter: "*", quotation: "$" }),
     ).toEqualTypeOf<
       IterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToIterableIterator(csv4, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      IterableIterator<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToIterableIterator(csv5, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      IterableIterator<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToIterableIterator(csv6, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      IterableIterator<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToIterableIterator(csv7, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      IterableIterator<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parseStringToIterableIterator.test-d.ts
+++ b/src/parseStringToIterableIterator.test-d.ts
@@ -91,6 +91,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToIterableIterator(csv1)).toEqualTypeOf<
       IterableIterator<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
@@ -131,6 +145,14 @@ les'@'@9
     ).toEqualTypeOf<
       IterableIterator<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(
+      parseStringToIterableIterator(csv7, { delimiter: "@", quotation: "'" }),
+    ).toEqualTypeOf<
+      IterableIterator<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
   });

--- a/src/parseStringToIterableIterator.ts
+++ b/src/parseStringToIterableIterator.ts
@@ -1,7 +1,8 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToIterableIterator<
   CSVSource extends string,

--- a/src/parseStringToIterableIterator.ts
+++ b/src/parseStringToIterableIterator.ts
@@ -1,13 +1,13 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToIterableIterator<
   CSVSource extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseStringToStream.test-d.ts
+++ b/src/parseStringToStream.test-d.ts
@@ -89,6 +89,20 @@ Bob@36@'Lo@s Ange
 les'@'@9
 0001'`;
 
+  const csv7 = `'@name'@'a'g'e
+
+'@'c
+@i''ty@'@'
+'zi
+p''
+'Al'ic'e@'@''24''@'@Ne
+w Yo'r'k'@'10
+00@1'
+'Bob'@36@'Lo@s A'nge'
+
+les'@'@9
+0001'''`;
+
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToStream(csv1)).toEqualTypeOf<
       ReadableStream<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
@@ -129,6 +143,14 @@ les'@'@9
     ).toEqualTypeOf<
       ReadableStream<
         CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
+      >
+    >();
+
+    expectTypeOf(
+      parseStringToStream(csv7, { delimiter: "@", quotation: "'" }),
+    ).toEqualTypeOf<
+      ReadableStream<
+        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
       >
     >();
   });

--- a/src/parseStringToStream.test-d.ts
+++ b/src/parseStringToStream.test-d.ts
@@ -1,5 +1,4 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { CR, CRLF, LF } from "./constants.ts";
 import { parseStringToStream } from "./parseStringToStream.ts";
 import type { CSVRecord, ParseOptions } from "./web-csv-toolbox.ts";
 
@@ -26,131 +25,29 @@ describe("csv literal string parsing", () => {
 Alice,24,New York,10001
 Bob,36,Los Angeles,90001`;
 
-  const csv2 = "name,age,city,zip";
-
   it("should csv header of the parsed result will be header's tuple", () => {
     expectTypeOf(parseStringToStream(csv1)).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age", "city", "zip"]>>
-    >();
-
-    expectTypeOf(parseStringToStream(csv2)).toEqualTypeOf<
       ReadableStream<CSVRecord<readonly ["name", "age", "city", "zip"]>>
     >();
   });
 });
 
 describe("csv literal string parsing with line breaks, quotation, newline", () => {
-  const csv1 = `"name","age
-","city","zi
-p"
-Alice,24,New York,10001
-Bob,36,Los Angeles,90001`;
-
-  const csv2 = `'name'@'age
-'@'city'@'zi
-p'
-Alice@24@New York@10001
-Bob@36@Los Angeles@90001`;
-
-  const csv3 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'
-Alice@'24'@'Ne
-w York'@'10
-001'
-Bob@36@'Los Ange
-
-les'@'9
-0001'`;
-
-  const csv4 = `'name'@'age
-
-'@'c
-ity'@'
-zi
-p'`;
-
-  const csv5 = `'na${CR}me'@'age'@'ci${CR}${CRLF}ty'@'z${LF}ip'${CR}Alice@24@'New${CR}${LF} York'@10001${LF}Bob@'3${CRLF}6'@'Los Angeles'@'90${CRLF}001'`;
-
-  const csv6 = `'@name'@'age
-
-'@'c
-@ity@'@'
-zi
-p'
-'Alice@'@'24'@'@Ne
-w York'@'10
-00@1'
-Bob@36@'Lo@s Ange
-
-les'@'@9
-0001'`;
-
-  const csv7 = `'@name'@'a'g'e
-
-'@'c
-@i''ty@'@'
-'zi
-p''
-'Al'ic'e@'@''24''@'@Ne
-w Yo'r'k'@'10
-00@1'
-'Bob'@36@'Lo@s A'nge'
-
-les'@'@9
-0001'''`;
+  const csv1 = `$name$*$*ag
+e
+$*$city$*$z*i
+p*$
+Alice*24*New York*$1000
+$1$
+Bob*$36$*$Los$
+Angeles$*90001`;
 
   it("should csv header of the parsed result will be header's tuple", () => {
-    expectTypeOf(parseStringToStream(csv1)).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
     expectTypeOf(
-      parseStringToStream(csv2, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      ReadableStream<CSVRecord<readonly ["name", "age\n", "city", "zi\np"]>>
-    >();
-
-    expectTypeOf(
-      parseStringToStream(csv3, { delimiter: "@", quotation: "'" }),
+      parseStringToStream(csv1, { delimiter: "*", quotation: "$" }),
     ).toEqualTypeOf<
       ReadableStream<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToStream(csv4, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["name", "age\n\n", "c\nity", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToStream(csv5, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["na\rme", "age", "ci\r\r\nty", "z\nip"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToStream(csv6, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["@name", "age\n\n", "c\n@ity@", "\nzi\np"]>
-      >
-    >();
-
-    expectTypeOf(
-      parseStringToStream(csv7, { delimiter: "@", quotation: "'" }),
-    ).toEqualTypeOf<
-      ReadableStream<
-        CSVRecord<readonly ["@name", "a'g'e\n\n", "c\n@i''ty@", "\n'zi\np'"]>
+        CSVRecord<readonly ["name", "*ag\ne\n", "city", "z*i\np*"]>
       >
     >();
   });

--- a/src/parseStringToStream.ts
+++ b/src/parseStringToStream.ts
@@ -1,13 +1,13 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
 import type { CSVRecord, ParseOptions } from "./common/types.ts";
-import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { DEFAULT_DELIMITER, DEFAULT_QUOTATION } from "./constants.ts";
 import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToStream<
   CSVSource extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Header extends ReadonlyArray<string> = PickCSVHeader<
     CSVSource,
     Delimiter,

--- a/src/parseStringToStream.ts
+++ b/src/parseStringToStream.ts
@@ -1,7 +1,8 @@
 import { Lexer } from "./Lexer.ts";
 import { RecordAssembler } from "./RecordAssembler.ts";
-import type { CSVRecord, ParseOptions, PickCSVHeader } from "./common/types.ts";
+import type { CSVRecord, ParseOptions } from "./common/types.ts";
 import type { COMMA, DOUBLE_QUOTE } from "./constants.ts";
+import type { PickCSVHeader } from "./utils/types.ts";
 
 export function parseStringToStream<
   CSVSource extends string,

--- a/src/utils/types.test-d.ts
+++ b/src/utils/types.test-d.ts
@@ -1,11 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest";
 import { CR, CRLF, LF } from "../constants";
-import type {
-  ExtractCSVHeader,
-  Join,
-  PickCSVHeader,
-  Split,
-} from "../utils/types";
+import type { ExtractCSVHeader, Join, PickCSVHeader, Split } from "./types";
 
 const case1csv1 = '"na\nme,",age,city,zip';
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,184 @@
+import type { COMMA, DOUBLE_QUOTE, Newline } from "../constants.ts";
+import type { CSVString } from "../web-csv-toolbox.ts";
+
+/**
+ * Generate new string by concatenating all of the elements in array.
+ *
+ * @category Types
+ *
+ * @example Default
+ *
+ * ```ts
+ * const csv = ["name", "age", "city", "zip"];
+ *
+ * type _ = Join<typeof csv>
+ * // `name,age,city,zip`
+ * ```
+ *
+ * @example With different delimiter and quotation
+ *
+ * ```ts
+ * const csv = ["name", "a\nge", "city", "zip"];
+ *
+ * type _ = Join<typeof csv, "@", "$">
+ * // `name@$a\nge$@city@zip`
+ * ```
+ */
+export type Join<
+  Chars extends ReadonlyArray<string | number | boolean | bigint>,
+  Delimiter extends string = typeof COMMA,
+  Quotation extends string = typeof DOUBLE_QUOTE,
+  Nl extends string = Exclude<Newline, Delimiter | Quotation>,
+> = Chars extends readonly [infer F, ...infer R]
+  ? F extends string
+    ? R extends string[]
+      ? `${F extends `${string}${Nl | Delimiter}${string}`
+          ? `${Quotation}${F}${Quotation}`
+          : F}${R extends [] ? "" : Delimiter}${Join<R, Delimiter, Quotation>}`
+      : string
+    : string
+  : "";
+
+/**
+ * Generate a delimiter-separated tuple from a string.
+ *
+ * @category Types
+ *
+ * @example Default
+ *
+ * ```ts
+ * const csv = `name,age,city,zip`;
+ *
+ * type _ = Split<typeof csv>
+ * // ["name", "age", "city", "zip"]
+ * ```
+ *
+ * @example With different delimiter and quotation
+ *
+ * ```ts
+ * const csv = `name@$a
+ * ge$@city@zip`;
+ *
+ * type _ = Split<typeof csv, "@", "$">
+ * // ["name", "a\nge", "city", "zip"]
+ * ```
+ */
+export type Split<
+  Char extends string,
+  Delimiter extends string = typeof COMMA,
+  Quotation extends string = typeof DOUBLE_QUOTE,
+  Escaping extends boolean = false,
+  Col extends string = "",
+  Result extends string[] = [],
+> = Char extends `${Delimiter}${infer R}`
+  ? Escaping extends true
+    ? Split<R, Delimiter, Quotation, true, `${Col}${Delimiter}`, Result>
+    : Split<R, Delimiter, Quotation, false, "", [...Result, Col]>
+  : Char extends `${Quotation}${infer R}`
+    ? Escaping extends true
+      ? R extends "" | Delimiter | `${Delimiter}${string}`
+        ? Split<R, Delimiter, Quotation, false, Col, Result>
+        : Split<R, Delimiter, Quotation, true, `${Col}${Quotation}`, Result>
+      : Split<R, Delimiter, Quotation, true, Col, Result>
+    : Char extends `${infer F}${infer R}`
+      ? Split<R, Delimiter, Quotation, Escaping, `${Col}${F}`, Result>
+      : [...Result, Col] extends [""]
+        ? readonly string[]
+        : readonly [...Result, Col];
+
+type ExtractString<Source extends CSVString> = Source extends
+  | `${infer S}`
+  // biome-ignore lint/suspicious/noRedeclare: <explanation>
+  | ReadableStream<infer S>
+  ? S
+  : string;
+
+/**
+ * Extract a CSV header string from a CSVString.
+ *
+ * @category Types
+ *
+ * @example Default
+ *
+ * ```ts
+ * const csv = `name,age
+ * Alice,42
+ * Bob,69`;
+ *
+ * type _ = ExtractCSVHeader<typeof csv>
+ * // "name,age"
+ * ```
+ *
+ * @example With different delimiter and quotation
+ *
+ * ```ts
+ * const csv = `name@$a
+ * ge$
+ * $Ali
+ * ce$@42
+ * Bob@69`;
+ *
+ * type _ = ExtractCSVHeader<typeof csv, "@", "$">
+ * // "name@$a\nge$"
+ * ```
+ */
+export type ExtractCSVHeader<
+  CSVSource extends CSVString,
+  Delimiter extends string = typeof COMMA,
+  Quotation extends string = typeof DOUBLE_QUOTE,
+  Nl extends string = Exclude<Newline, Delimiter | Quotation>,
+  Escaping extends boolean = false,
+  Result extends string = "",
+> = ExtractString<CSVSource> extends `${Quotation}${infer R}`
+  ? Escaping extends true
+    ? R extends Delimiter | Nl | `${Delimiter | Nl}${string}`
+      ? // biome-ignore format: <explanation>
+        ExtractCSVHeader<R, Delimiter, Quotation, Nl, false, `${Result}${Quotation}`>
+      : // biome-ignore format: <explanation>
+        ExtractCSVHeader<R, Delimiter, Quotation, Nl, true, `${Result}${Quotation}`>
+    : // biome-ignore format: <explanation>
+      ExtractCSVHeader<R, Delimiter, Quotation, Nl, true, `${Result}${Quotation}`>
+  : ExtractString<CSVSource> extends `${infer N extends Nl}${infer R}`
+    ? Escaping extends true
+      ? ExtractCSVHeader<R, Delimiter, Quotation, Nl, true, `${Result}${N}`>
+      : Result
+    : ExtractString<CSVSource> extends `${infer F}${infer R}`
+      ? ExtractCSVHeader<R, Delimiter, Quotation, Nl, Escaping, `${Result}${F}`>
+      : Result;
+
+/**
+ * Generates a delimiter-separated tuple of CSV headers from a CSVString.
+ *
+ * @category Types
+ *
+ * @example Default
+ *
+ * ```ts
+ * const csv = `name,age
+ * Alice,42
+ * Bob,69`;
+ *
+ * type _ = PickCSVHeader<typeof csv>
+ * // ["name", "age"]
+ * ```
+ *
+ * @example With different delimiter and quotation
+ *
+ * ```ts
+ * const csv = `name@$a
+ * ge$
+ * $Ali
+ * ce$@42
+ * Bob@69`;
+ *
+ * type _ = PickCSVHeader<typeof csv, "@", "$">
+ * // ["name", "a\nge"]
+ * ```
+ */
+export type PickCSVHeader<
+  CSVSource extends CSVString,
+  Delimiter extends string = typeof COMMA,
+  Quotation extends string = typeof DOUBLE_QUOTE,
+> = ExtractString<CSVSource> extends `${infer S}`
+  ? Split<ExtractCSVHeader<S, Delimiter, Quotation>, Delimiter, Quotation>
+  : ReadonlyArray<string>;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,8 @@
-import type { COMMA, DOUBLE_QUOTE, Newline } from "../constants.ts";
+import type {
+  DEFAULT_DELIMITER,
+  DEFAULT_QUOTATION,
+  Newline,
+} from "../constants.ts";
 import type { CSVString } from "../web-csv-toolbox.ts";
 
 /**
@@ -26,8 +30,8 @@ import type { CSVString } from "../web-csv-toolbox.ts";
  */
 export type Join<
   Chars extends ReadonlyArray<string | number | boolean | bigint>,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Nl extends string = Exclude<Newline, Delimiter | Quotation>,
 > = Chars extends readonly [infer F, ...infer R]
   ? F extends string
@@ -65,8 +69,8 @@ export type Join<
  */
 export type Split<
   Char extends string,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Escaping extends boolean = false,
   Col extends string = "",
   Result extends string[] = [],
@@ -124,8 +128,8 @@ type ExtractString<Source extends CSVString> = Source extends
  */
 export type ExtractCSVHeader<
   CSVSource extends CSVString,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
   Nl extends string = Exclude<Newline, Delimiter | Quotation>,
   Escaping extends boolean = false,
   Result extends string = "",
@@ -177,8 +181,8 @@ export type ExtractCSVHeader<
  */
 export type PickCSVHeader<
   CSVSource extends CSVString,
-  Delimiter extends string = typeof COMMA,
-  Quotation extends string = typeof DOUBLE_QUOTE,
+  Delimiter extends string = DEFAULT_DELIMITER,
+  Quotation extends string = DEFAULT_QUOTATION,
 > = ExtractString<CSVSource> extends `${infer S}`
   ? Split<ExtractCSVHeader<S, Delimiter, Quotation>, Delimiter, Quotation>
   : ReadonlyArray<string>;


### PR DESCRIPTION
The CSV functions correctly for up to 100 columns. However, when the number of columns exceeds that, the following error is encountered.

```bash
Type instantiation is excessively deep and possibly infinite.ts(2589)
```

In that case, it is necessary to specify as follows.

```ts
const csv = 'many,columns,here';
parse<string>(csv);
```

```ts
import type { CSV } from "./web-csv-toolbox.ts";

const csv: CSV = 'many,columns,here';
parse(csv);
```
